### PR TITLE
fix: the scroll bar may overlap the text conent on the right side

### DIFF
--- a/src/components/rule-card.tsx
+++ b/src/components/rule-card.tsx
@@ -22,14 +22,14 @@ export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {
     <Card className="bg-background p-4 max-h-[calc(100vh-8rem)] aspect-square flex flex-col">
       <CardContent
         className={cn(
-          "bg-card h-full mb-2 font-mono p-4 text-sm opacity-50 hover:opacity-100 transition-opacity group relative flex-grow",
+          "bg-card h-full mb-2 font-mono p-4 pr-1 text-sm opacity-50 hover:opacity-100 transition-opacity group relative flex-grow",
           isPage && "opacity-100",
         )}
       >
         <CopyButton content={rule.content} />
         <Link href={`/${rule.slug}`}>
           <ScrollArea className="h-full">
-            <code className="text-sm">{rule.content}</code>
+            <code className="text-sm block pr-3">{rule.content}</code>
           </ScrollArea>
         </Link>
       </CardContent>


### PR DESCRIPTION
the scroll bar can overlap the text conent on the right side. fixed by move scroll bar right.
before:
![Kapture 2024-08-27 at 18 26 33](https://github.com/user-attachments/assets/29c9543b-f42d-4b0e-80eb-2dfdd3362bac)

after fix:
![Kapture 2024-08-27 at 18 27 51](https://github.com/user-attachments/assets/93e3c94a-254d-44a7-ad89-baea2bda4837)
