### PR TITLE
feat: add popover component and apply it to tags, displaying all of them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-context-menu": "^2.2.1",
         "@radix-ui/react-dialog": "^1.1.1",
+        "@radix-ui/react-popover": "^1.1.1",
         "@radix-ui/react-scroll-area": "^1.1.0",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
@@ -791,6 +792,42 @@
         "@radix-ui/react-roving-focus": "1.1.0",
         "@radix-ui/react-slot": "1.1.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.1.tgz",
+      "integrity": "sha512-3y1A3isulwnWhvTTwmIreiB8CF4L+qRjZnK1wYLO7pplddzXKby/GnZ2M7OZY3qgnl6p9AodUIHRYGXNah8Y7g==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.5.7"
       },
@@ -3162,6 +3199,28 @@
         "@radix-ui/react-roving-focus": "1.1.0",
         "@radix-ui/react-slot": "1.1.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      }
+    },
+    "@radix-ui/react-popover": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.1.tgz",
+      "integrity": "sha512-3y1A3isulwnWhvTTwmIreiB8CF4L+qRjZnK1wYLO7pplddzXKby/GnZ2M7OZY3qgnl6p9AodUIHRYGXNah8Y7g==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.5.7"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-context-menu": "^2.2.1",
     "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-scroll-area": "^1.1.0",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
@@ -30,11 +31,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "typescript": "^5",
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "postcss": "^8",
-    "tailwindcss": "^3.4.10"
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5"
   }
 }

--- a/src/components/rule-card.tsx
+++ b/src/components/rule-card.tsx
@@ -47,7 +47,7 @@ export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {
         </div>
 
         <Popover>
-          <PopoverTrigger className="flex gap-2 items-center overflow-x-auto whitespace-nowrap h-5 cursor-pointer hover:bg-accent rounded">
+          <PopoverTrigger className="flex gap-2 items-center overflow-x-auto whitespace-nowrap h-5 cursor-pointer hover:bg-accent">
             {rule?.libs?.slice(0, 2).map((lib) => (
               <span
                 key={lib}

--- a/src/components/rule-card.tsx
+++ b/src/components/rule-card.tsx
@@ -1,7 +1,9 @@
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 import { CopyButton } from "./copy-button";
 
@@ -17,7 +19,7 @@ export type Rule = {
   };
 };
 
-export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {
+export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {  
   return (
     <Card className="bg-background p-4 max-h-[calc(100vh-8rem)] aspect-square flex flex-col">
       <CardContent
@@ -44,21 +46,33 @@ export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {
           </Avatar>
         </div>
 
-        <div className="flex gap-2 overflow-x-auto whitespace-nowrap h-5">
-          {rule?.libs?.slice(0, 2).map((lib) => (
-            <span
-              key={lib}
-              className="text-xs text-[#878787] font-mono flex-shrink-0"
-            >
-              {lib}
-            </span>
-          ))}
-          {rule?.libs && rule.libs.length > 2 && (
-            <span className="text-xs text-[#878787] font-mono flex-shrink-0">
-              +{rule.libs.length - 2} more
-            </span>
-          )}
-        </div>
+        <Popover>
+          <PopoverTrigger className="flex gap-2 items-center overflow-x-auto whitespace-nowrap h-5 cursor-pointer hover:bg-accent rounded">
+            {rule?.libs?.slice(0, 2).map((lib) => (
+              <span
+                key={lib}
+                className="text-xs text-[#878787] font-mono flex-shrink-0"
+              >
+                {lib}
+              </span>
+            ))}
+            {rule?.libs && rule.libs.length > 2 && (
+              <span className="text-xs text-[#878787] font-mono flex gap-1 items-center">
+                <span>+{rule.libs.length - 2} more</span>
+                <ChevronDown className="w-3 h-3" />
+              </span>
+            )}
+          </PopoverTrigger>
+          <PopoverContent>
+            {rule?.libs?.map((lib) => (
+              <div key={lib} className="flex flex-col justify-center gap-2">
+                <span className="text-xs text-[#878787] font-mono flex-shrink-0">
+                  {lib}
+                </span>
+              </div>
+            ))}
+          </PopoverContent>
+        </Popover>
       </CardHeader>
     </Card>
   );

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverContent, PopoverTrigger }


### PR DESCRIPTION
**Problem:** The current UI displays only a limited number of tags (up to three), with the remaining tags hidden behind a "+X more" indicator. This restricts users from viewing all the tags associated with a prompt, which can be inconvenient and impact the user experience.

**Solution:** This PR introduces the Popover component from Shadcn to improve the tag display functionality. By utilizing the Popover component, users can now click on the "+X more" indicator to expand and view all tags in a neatly organized manner. This enhancement ensures that all tags are accessible on both mobile and desktop platforms.

Mobile:
![image](https://github.com/user-attachments/assets/9a4bb9ed-bd31-401a-b8b4-07e9c29be347)
![image](https://github.com/user-attachments/assets/252d60d9-7755-4115-a122-c32f5b41096c)


Desktop:
![image](https://github.com/user-attachments/assets/faaec8b6-b766-4b83-9669-685575c21e16)
![image](https://github.com/user-attachments/assets/037cce63-9af6-4231-8a28-6ff71362d071)

