### PR TITLE
fix(avatar): use name abbr fallback when avatar is invalid

### DIFF
--- a/src/components/rule-card.tsx
+++ b/src/components/rule-card.tsx
@@ -52,33 +52,35 @@ export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {
             </Avatar>
           </a>
         </div>
-        <Popover>
-          <PopoverTrigger className="flex gap-2 items-center overflow-x-auto whitespace-nowrap h-5 cursor-pointer hover:bg-accent">
-            {rule?.libs?.slice(0, 2).map((lib) => (
-              <span
-                key={lib}
-                className="text-xs text-[#878787] font-mono flex-shrink-0"
-              >
-                {lib}
-              </span>
-            ))}
-            {rule?.libs && rule.libs.length > 2 && (
-              <span className="text-xs text-[#878787] font-mono flex gap-1 items-center">
-                <span>+{rule.libs.length - 2} more</span>
-                <ChevronDown className="w-3 h-3" />
-              </span>
-            )}
-          </PopoverTrigger>
-          <PopoverContent>
-            {rule?.libs?.map((lib) => (
-              <div key={lib} className="flex flex-col justify-center gap-2">
-                <span className="text-xs text-[#878787] font-mono flex-shrink-0">
+        {
+          rule.libs && rule.libs.length > 0 && <Popover>
+            <PopoverTrigger className="flex gap-2 items-center overflow-x-auto whitespace-nowrap h-5 cursor-pointer hover:bg-accent">
+              {rule.libs.slice(0, 2).map((lib) => (
+                <span
+                  key={lib}
+                  className="text-xs text-[#878787] font-mono flex-shrink-0"
+                >
                   {lib}
                 </span>
-              </div>
-            ))}
-          </PopoverContent>
-        </Popover>
+              ))}
+              {rule.libs.length > 2 && (
+                <span className="text-xs text-[#878787] font-mono flex gap-1 items-center">
+                  <span>+{rule.libs.length - 2} more</span>
+                  <ChevronDown className="w-3 h-3" />
+                </span>
+              )}
+            </PopoverTrigger>
+            <PopoverContent>
+              {rule.libs.map((lib) => (
+                <div key={lib} className="flex flex-col justify-center gap-2">
+                  <span className="text-xs text-[#878787] font-mono flex-shrink-0">
+                    {lib}
+                  </span>
+                </div>
+              ))}
+            </PopoverContent>
+          </Popover>
+        }
       </CardHeader>
     </Card>
   );

--- a/src/components/rule-card.tsx
+++ b/src/components/rule-card.tsx
@@ -1,8 +1,8 @@
-import { Avatar, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { cn } from "@/lib/utils";
+import { cn, generateNameAbbr, isImageUrl } from "@/lib/utils";
 import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 import { CopyButton } from "./copy-button";
@@ -20,7 +20,7 @@ export type Rule = {
   };
 };
 
-export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {  
+export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {
   return (
     <Card className="bg-background p-4 max-h-[calc(100vh-8rem)] aspect-square flex flex-col">
       <CardContent
@@ -44,13 +44,14 @@ export function RuleCard({ rule, isPage }: { rule: Rule; isPage?: boolean }) {
       <CardHeader className="p-0 space-y-1">
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm">{rule.author.name}</CardTitle>
-          <Avatar className="size-6">
-            <a href={rule.author.url} target="_blank" rel="noopener noreferrer">
-              <AvatarImage src={rule.author.avatar} alt={rule.author.name} />
-            </a>
-          </Avatar>
+          <a href={rule.author.url} target="_blank" rel="noopener noreferrer">
+            <Avatar className="size-6">
+              {
+                isImageUrl(rule.author.avatar) ? <AvatarImage src={rule.author.avatar} alt={rule.author.name} /> : <AvatarFallback>{generateNameAbbr(rule.author.name)}</AvatarFallback>
+              }
+            </Avatar>
+          </a>
         </div>
-
         <Popover>
           <PopoverTrigger className="flex gap-2 items-center overflow-x-auto whitespace-nowrap h-5 cursor-pointer hover:bg-accent">
             {rule?.libs?.slice(0, 2).map((lib) => (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,21 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function isImageUrl(url: string): boolean {
+  const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp'];
+
+  const isDataUri = url.startsWith('data:image/');
+
+  const isImageExtension = imageExtensions.includes(url.substring(url.lastIndexOf('.')).toLowerCase()) || url.endsWith('.svg');
+
+  return isDataUri || isImageExtension;
+}
+
+export function generateNameAbbr(name: string): string {
+  const firstCharRegex = /[\p{L}]/u;
+
+  const match = name.match(firstCharRegex);
+
+  return match ? match[0].toUpperCase() : '';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +23,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
# avatar

I noticed that some users didn't provide valid url for avatar. 

The commit allows to use first non-emoji char from author name as fallback.

# popover

There is a blank clickable popover when the `libs` is an empty array. I am not sure if it's allowed to not render it.