### PR TITLE
[Update] Update the Astro template - `@astrojs/image` is deprecated + other changes

### DIFF
--- a/src/data/rules/astro.ts
+++ b/src/data/rules/astro.ts
@@ -9,7 +9,7 @@ export const astroRules = [
 
   Key Principles
   - Write concise, technical responses with accurate Astro examples.
-  - Leverage Astro's partial hydration and multi-framework support effectively.
+  - Leverage Astro's partial hydration and islands architecture effectively.
   - Prioritize static generation and minimal JavaScript for optimal performance.
   - Use descriptive variable names and follow Astro's naming conventions.
   - Organize files using Astro's file-based routing system.
@@ -26,10 +26,10 @@ export const astroRules = [
 
   Component Development
   - Create .astro files for Astro components.
-  - Use framework-specific components (React, Vue, Svelte) when necessary.
+  - Use framework-specific components (React, Vue, Svelte) only when required.
   - Implement proper component composition and reusability.
   - Use Astro's component props for data passing.
-  - Leverage Astro's built-in components like <Markdown /> when appropriate.
+  - Leverage Astro's content-driven components when appropriate.
 
   Routing and Pages
   - Utilize Astro's file-based routing system in the src/pages/ directory.
@@ -40,44 +40,44 @@ export const astroRules = [
   Content Management
   - Use Markdown (.md) or MDX (.mdx) files for content-heavy pages.
   - Leverage Astro's built-in support for frontmatter in Markdown files.
-  - Implement content collections for organized content management.
+  - Implement typed content collections for organized content management.
 
   Styling
   - Use Astro's scoped styling with <style> tags in .astro files.
   - Leverage global styles when necessary, importing them in layouts.
   - Utilize CSS preprocessing with Sass or Less if required.
-  - Implement responsive design using CSS custom properties and media queries.
+  - Implement responsive design using modern CSS features and media queries.
 
   Performance Optimization
   - Minimize use of client-side JavaScript; leverage Astro's static generation.
   - Use the client:* directives judiciously for partial hydration:
     - client:load for immediately needed interactivity
     - client:idle for non-critical interactivity
-    - client:visible for components that should hydrate when visible
-  - Implement proper lazy loading for images and other assets.
-  - Utilize Astro's built-in asset optimization features.
+    - client:visible for components that hydrate when visible
+  - Implement modern image handling through Astro's asset pipeline.
+  - Utilize Astro's built-in optimization features for all assets.
 
   Data Fetching
   - Use Astro.props for passing data to components.
   - Implement getStaticPaths() for fetching data at build time.
-  - Use Astro.glob() for working with local files efficiently.
+  - Use content collections for efficient content management.
   - Implement proper error handling for data fetching operations.
 
   SEO and Meta Tags
-  - Use Astro's <head> tag for adding meta information.
-  - Implement canonical URLs for proper SEO.
-  - Use the <SEO> component pattern for reusable SEO setups.
+  - Use Astro's metadata utilities for structured SEO implementation.
+  - Implement canonical URLs and semantic markup for SEO.
+  - Follow modern SEO patterns with proper schema.org markup.
 
   Integrations and Plugins
   - Utilize Astro integrations for extending functionality.
   - Use Astro's built-in assets handling for optimized image delivery.
   - Implement proper configuration for integrations in astro.config.mjs.
-  - Use Astro's official integrations when available for better compatibility.
+  - Prefer Astro's official integrations for better compatibility.
 
   Build and Deployment
   - Optimize the build process using Astro's build command.
   - Implement proper environment variable handling for different environments.
-  - Use static hosting platforms compatible with Astro (Netlify, Vercel, etc.).
+  - Use static hosting platforms compatible with Astro (Netlify, Vercel, GitHub Pages, etc.).
   - Implement proper CI/CD pipelines for automated builds and deployments.
 
   Styling with Tailwind CSS
@@ -105,7 +105,7 @@ export const astroRules = [
   2. Use TypeScript for enhanced type safety and developer experience.
   3. Implement proper error handling and logging.
   4. Leverage Astro's RSS feed generation for content-heavy sites.
-  5. Use Astro's Image component for optimized image delivery.
+  5. Use Astro's modern asset handling for optimized delivery.
 
   Performance Metrics
   - Prioritize Core Web Vitals (LCP, FID, CLS) in development.

--- a/src/data/rules/astro.ts
+++ b/src/data/rules/astro.ts
@@ -69,7 +69,8 @@ export const astroRules = [
   - Use the <SEO> component pattern for reusable SEO setups.
 
   Integrations and Plugins
-  - Utilize Astro integrations for extending functionality (e.g., @astrojs/image).
+  - Utilize Astro integrations for extending functionality.
+  - Use Astro's built-in assets handling for optimized image delivery.
   - Implement proper configuration for integrations in astro.config.mjs.
   - Use Astro's official integrations when available for better compatibility.
 


### PR DESCRIPTION
Hello.

This update modernizes the Astro rules to reflect current best practices and changes in Astro v5+. 

**Key updates include:**
- Removed deprecated `@astrojs/image` references in favor of Astro's built-in asset handling
- Updated content collection guidance with type safety
- Modernized asset handling recommendations
- Revised SEO section to reflect metadata utilities
- Updated data fetching to emphasize content collections
- Added GitHub Pages as a deployment option
- General modernization of performance optimization section
- Updated component development guidelines to reflect islands architecture

**Reason for Changes:**
- The `@astrojs/image` integration is no longer maintained and has been removed in Astro v3
- Astro now provides native support for optimized image handling
- Content collections now support type safety out of the box
- Modern SEO practices have evolved with Astro's metadata utilities
- Performance optimization strategies have been updated for modern web standards
- GitHub Pages is a popular and accessible deployment option for Astro projects

**References:**
1. [Astro v3 Migration Guide: Removed `@astrojs/image`](https://docs.astro.build/en/guides/upgrade-to/v3/#removed-astrojsimage)
2. [Astro Assets Handling](https://docs.astro.build/en/guides/images/)
3. [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/)
4. [Astro SEO and Metadata](https://docs.astro.build/en/guides/configuring-astro/#add-site-metadata)
5. [Deploying to GitHub Pages](https://docs.astro.build/en/guides/deploy/github/)
