### PR TITLE
fix(header): replace div with span to fix DOM nesting violation

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -82,7 +82,7 @@ export function Header() {
                   Submit
                 </Button>
               </a>
-              <div className="flex items-center space-x-1 mt-8 justify-center">
+              <span className="flex items-center space-x-1 mt-8 justify-center">
                 Made by{" "}
                 <a href="https://midday.ai">
                   <svg
@@ -104,7 +104,7 @@ export function Header() {
                     />
                   </svg>
                 </a>
-              </div>
+              </span>
             </DialogDescription>
           </DialogContent>
         </Dialog>


### PR DESCRIPTION
…when viewing About. See screenshots.

<img width="1512" alt="about-1" src="https://github.com/user-attachments/assets/670c1709-cba9-4e5c-95bf-69712e4ef6c7" />
<img width="1512" alt="about-2" src="https://github.com/user-attachments/assets/e255ff4d-aa73-426a-81d6-674b7f415d6c" />
