### PR TITLE
Added BrowserToolsMCP server

### DIFF
--- a/src/data/mcp/data.json
+++ b/src/data/mcp/data.json
@@ -141,5 +141,10 @@
     "name": "Google Drive",
     "url": "https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive",
     "description": "File access and search capabilities for Google Drive"
+  },
+  {
+    "name": "BrowserTools MCP",
+    "url": "https://github.com/AgentDeskAI/browser-tools-mcp",
+    "description": "Analyze logs & interact with your browser for rapid debugging"
   }
 ]


### PR DESCRIPTION
I have added my MCP tool called BrowserTools which is used to monitor/capture logs from the browser, capture screenshots and get the currently selected element. I added this to the /data/mcp/data.json directory with no other changes made elsewhere and have tested this locally.